### PR TITLE
Replace uninitialized @separator with @word_separator in NGram#parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ngram = NGram.new({
   :word_separator => " ",
   :padchar => "_"
 })
-# => #<NGram:0x10d9877f0 @padchar="_", @separator=" ", @size=2>
+# => #<NGram:0x10d9877f0 @padchar="_", @word_separator=" ", @size=2>
 
 ngram.parse('test')
 # => ["__", "_t", "te", "es", "st", "t_", "__"]

--- a/lib/ngram.rb
+++ b/lib/ngram.rb
@@ -9,7 +9,7 @@ class NGram
     end
 
     def parse(phrase)
-        words = phrase.split(@separator)
+        words = phrase.split(@word_separator)
         if words.length == 1
             process(phrase)
         else


### PR DESCRIPTION
## Problem Overview
In the `parse` method of the `NGram` class, `@separator` was being used without being properly defined or initialized. However, due to Ruby's behavior, `split(nil)` defaulted to splitting by whitespace, so no error was occurring.

The code will not behave as expected when trying to specify a custom separator.

## Fix Details
`@separator` has been replaced with `@word_separator` to ensure that an intentionally set separator is used.